### PR TITLE
Use Jetty as the container runtime image.

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -5,7 +5,7 @@ RUN git clone -b R2_17_0 git://git.eclipse.org/gitroot/xsd/org.eclipse.xsd.git
 WORKDIR org.eclipse.emf
 RUN mvn install
 
-FROM maven:3.6-jdk-8
+FROM maven:3.6-jdk-8 as build
 
 COPY --from=emf-build /root/.m2/ /root/.m2/
 COPY org.opentestmodeling.vstep.ngt.core.parent/ apps/
@@ -13,9 +13,8 @@ COPY org.opentestmodeling.vstep.ngt.core.parent/ apps/
 WORKDIR apps
 RUN mvn clean install -DskipTest
 
-EXPOSE 8080
+FROM jetty:9.4.18-jre8
 
-WORKDIR org.opentestmodeling.vstep.ngt.core.web
-RUN mvn org.apache.maven.plugins:maven-dependency-plugin:3.0.1:go-offline
+WORKDIR $JETTY_BASE
 
-CMD mvn jetty:run
+COPY --from=build /apps/org.opentestmodeling.vstep.ngt.core.web/target/org.opentestmodeling.vstep.ngt.core.web-0.0.1-SNAPSHOT.war webapps/ROOT.war


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>